### PR TITLE
Feature/delete account UI

### DIFF
--- a/pages/profile.html
+++ b/pages/profile.html
@@ -83,11 +83,31 @@
                         <div id="marketing_agree" class="info-value">로딩 중...</div>
                     </div>
                 </div>
+
+                <div class="profile-section">
+                    <h2 class="section-title">계정 관리</h2>
+                    <div class="account-management">
+                        <p class="withdrawal-warning">회원 탈퇴 시 모든 데이터가 삭제되며 복구할 수 없습니다.</p>
+                        <button id="withdrawalBtn" class="btn-withdrawal">회원 탈퇴</button>
+                    </div>
+                </div>
             </div>
         </div>
     </main>
 
     <!-- 푸터는 components.js에서 삽입됨 -->
+
+    <!-- 회원 탈퇴 확인 모달 -->
+    <div id="withdrawalModal" class="modal">
+        <div class="modal-content">
+            <h2>정말 탈퇴하시겠습니까?</h2>
+            <p>회원 탈퇴 시 모든 개인정보와 활동 내역이 삭제되며 복구할 수 없습니다.</p>
+            <div class="modal-actions">
+                <button id="cancelWithdrawal" class="btn-cancel">취소</button>
+                <button id="confirmWithdrawal" class="btn-confirm">탈퇴하기</button>
+            </div>
+        </div>
+    </div>
 
 </body>
 </html>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -127,3 +127,20 @@ export async function getSubRegions() {
         throw new Error(error.response?.data?.detail || "지역 목록 조회 실패. 다시 시도하세요.");
     }
 }
+
+// 회원 탈퇴 요청 (DELETE /api/v1/accounts/delete/)
+export async function deleteAccount() {
+    try {
+        const response = await axiosInstance.delete("/accounts/delete/");
+        
+        // 탈퇴 성공 시 로컬 스토리지 초기화
+        localStorage.removeItem("access_token");
+        localStorage.removeItem("refresh_token");
+        localStorage.removeItem("user");
+
+        return { message: "회원 탈퇴가 완료되었습니다." };
+    } catch (error) {
+        console.error("회원 탈퇴 실패:", error.response?.data || error.message);
+        throw new Error(error.response?.data?.detail || "회원 탈퇴 실패. 다시 시도하세요.");
+    }
+}

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,4 +1,4 @@
-import { getUserProfile } from "./api.js";
+import { getUserProfile, deleteAccount } from "./api.js";
 
 document.addEventListener("DOMContentLoaded", function () {
     loadUserProfile();
@@ -95,4 +95,44 @@ document.addEventListener("DOMContentLoaded", function () {
     function showMessage(message, type) {
         alert(message);
     }
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+    // 회원 탈퇴 모달 관련 요소 가져오기
+    const withdrawalModal = document.getElementById("withdrawalModal");
+    const withdrawalBtn = document.getElementById("withdrawalBtn");
+    const cancelWithdrawal = document.getElementById("cancelWithdrawal");
+    const confirmWithdrawal = document.getElementById("confirmWithdrawal");
+
+    // 회원 탈퇴 버튼 클릭 시 모달 표시
+    withdrawalBtn.addEventListener("click", () => {
+        withdrawalModal.classList.add("show");
+    });
+
+    // 취소 버튼 클릭 시 모달 닫기
+    cancelWithdrawal.addEventListener("click", () => {
+        withdrawalModal.classList.remove("show");
+    });
+
+    // 모달 외부 클릭 시 닫기
+    withdrawalModal.addEventListener("click", (event) => {
+        if (event.target === withdrawalModal) {
+            withdrawalModal.classList.remove("show");
+        }
+    });
+
+    // 회원 탈퇴 확인 버튼 클릭 시 API 호출
+    confirmWithdrawal.addEventListener("click", async () => {
+        try {
+            await deleteAccount();
+
+            alert("회원 탈퇴가 완료되었습니다.");
+            window.location.href = "/"; // 메인 페이지로 이동
+        } catch (error) {
+            console.error("회원 탈퇴 중 오류가 발생했습니다:", error);
+            alert("회원 탈퇴 처리 중 오류가 발생했습니다. 다시 시도해주세요.");
+        } finally {
+            withdrawalModal.classList.remove("show");
+        }
+    });
 });

--- a/styles/profile.css
+++ b/styles/profile.css
@@ -80,7 +80,7 @@ main.container {
   .profile-container {
     padding: 24px;
   }
-  
+
   .info-grid {
     grid-template-columns: 1fr;
     gap: 16px;
@@ -145,3 +145,100 @@ main.container {
   color: #767676;
   font-style: italic;
 }
+
+/* 회원 탈퇴 버튼 스타일 */
+.account-management {
+  margin-top: 16px;
+}
+
+.withdrawal-warning {
+  color: #767676;
+  font-size: 14px;
+  margin-bottom: 16px;
+}
+
+.btn-withdrawal {
+  background-color: transparent;
+  border: 1px solid #da1e28;
+  color: #da1e28;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-withdrawal:hover {
+  background-color: rgba(218, 30, 40, 0.1);
+}
+
+/* 모달 스타일 */
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  align-items: center;
+  justify-content: center;
+}
+
+.modal.show {
+  display: flex;
+}
+
+.modal-content {
+  background-color: white;
+  padding: 32px;
+  border-radius: 8px;
+  max-width: 480px;
+  width: 90%;
+}
+
+.modal-content h2 {
+  font-size: 20px;
+  margin: 0 0 16px 0;
+}
+
+.modal-content p {
+  margin-bottom: 24px;
+  color: #333;
+  line-height: 1.5;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.btn-cancel {
+  background-color: transparent;
+  border: 1px solid #8d8d8d;
+  color: #333;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.btn-confirm {
+  background-color: #da1e28;
+  border: none;
+  color: white;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.btn-confirm:hover {
+  background-color: #b81921;
+}
+


### PR DESCRIPTION
## 관련 이슈
- 해당없음

## 작업 내용
- `profile.html`에 **계정 관리 섹션 추가** 및 **회원 탈퇴 모달 구현**
- `profile.css`에 **회원 탈퇴 버튼 및 모달 스타일 추가**
- `api.js`에 **회원 탈퇴 API (`deleteAccount`) 추가** 및 **로컬 스토리지 초기화**
- `profile.js`에 **회원 탈퇴 모달 표시 및 API 호출 기능 추가**

## 테스트 체크리스트
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
![image](https://github.com/user-attachments/assets/94ebf5d9-0992-4885-8807-5004556595d9)
![image](https://github.com/user-attachments/assets/7a60a37c-8f31-4444-9424-fcb44971cdf5)
![image](https://github.com/user-attachments/assets/730017d1-938f-45c3-8876-334fd39d6c33)

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->
- 회원 탈퇴 시 **JWT 토큰 및 사용자 데이터 삭제 후 메인 페이지로 리디렉션**
- 회원 탈퇴 확인 모달을 통해 **사용자 실수 방지 기능 추가**
